### PR TITLE
update to compatibility with Guava 20, add basic gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Intellij workspace directory and files
+**/.idea/
+**/*.iml
+
+# Output directory for JET classes and binaries
+Jet/target
+
+# log and other test files/directories
+Jet/log.txt
+Jet/JET/src/test/resources/test-output/

--- a/Jet/pom.xml
+++ b/Jet/pom.xml
@@ -49,7 +49,7 @@
   	<dependency>
   		<groupId>com.google.guava</groupId>
   		<artifactId>guava</artifactId>
-  		<version>14.0</version>
+  		<version>20.0</version>
   	</dependency>
 
     <dependency>

--- a/Jet/src/main/java/org/jnbis/imageio/WSQImageReader.java
+++ b/Jet/src/main/java/org/jnbis/imageio/WSQImageReader.java
@@ -100,8 +100,7 @@ public class WSQImageReader extends ImageReader {
                 return;
             }
             if (!(input instanceof ImageInputStream)) { throw new IllegalArgumentException("bad input: " + input.getClass().getCanonicalName()); }
-            final Stopwatch stopwatch = new Stopwatch();
-            stopwatch.start();
+            final Stopwatch stopwatch = Stopwatch.createStarted();
             log.debug("Input:{}",getInput());
             final BitmapWithMetadata bitmap = WSQDecoder.decode((ImageInputStream)getInput());
             stopwatch.stop();

--- a/Jet/src/test/java/org/mitre/jet/ebts/WsqEncoderTest.java
+++ b/Jet/src/test/java/org/mitre/jet/ebts/WsqEncoderTest.java
@@ -56,8 +56,7 @@ public class WsqEncoderTest {
 
     @Test
     public void testBmp500() throws Exception {
-        Stopwatch stopwatch = new Stopwatch();
-        stopwatch.start();
+        Stopwatch stopwatch = Stopwatch.createStarted();
         ImageIO.setUseCache(false);
 
         File imageFile = new File(ClassLoader.getSystemResource("sample-gray-500.bmp").toURI());
@@ -74,8 +73,7 @@ public class WsqEncoderTest {
 
     @Test
     public void testBmpNonBiometric() throws Exception {
-        Stopwatch stopwatch = new Stopwatch();
-        stopwatch.start();
+        Stopwatch stopwatch = Stopwatch.createStarted();
         ImageIO.setUseCache(false);
 
         File imageFile = new File(ClassLoader.getSystemResource("image_not_provided.bmp").toURI());
@@ -149,8 +147,7 @@ public class WsqEncoderTest {
 
     @Test
     public void testPng() throws Exception {
-        Stopwatch stopwatch = new Stopwatch();
-        stopwatch.start();
+        Stopwatch stopwatch = Stopwatch.createStarted();
         ImageIO.setUseCache(false);
 
 


### PR DESCRIPTION
This will fix runtime compatibility issues with newer versions of many libraries that use Google Commons and pull in a dependency of Guava at 17 and higher, such as SpringFox in Swagger/UI.

Context:
Guava deprecates a public constructor in Stopwatch as of 17, so the factory must be used instead.